### PR TITLE
SDAP-31 TimeSeriesTile to accept ShapedArray for time

### DIFF
--- a/src/main/proto/DataTile.proto
+++ b/src/main/proto/DataTile.proto
@@ -50,7 +50,7 @@ message TimeSeriesTile{
     ShapedArray latitude = 1;
     ShapedArray longitude = 2;
 
-    int64 time = 3;
+    ShapedArray time = 3;
 
     ShapedArray variable_data = 4;
 


### PR DESCRIPTION
This PR changes the time attribute of TimeSeriesTile messages to be ShapedArray instead of int64 so we can store multiple times per tile.