### PR TITLE
SDAP-322 add multi variable data types

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-theVersion=1.0.1
+theVersion=1.1.0
 theName=nexusproto
 theGroup=org.apache.sdap
 theSourceCompatibility=1.8

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-theVersion=1.0.0
+theVersion=1.0.1
 theName=nexusproto
 theGroup=org.apache.sdap
 theSourceCompatibility=1.8

--- a/src/main/proto/DataTile.proto
+++ b/src/main/proto/DataTile.proto
@@ -51,7 +51,36 @@ message GridTile{
 
 }
 
+message GridMultiBandTile{
+
+    ShapedArray latitude = 1;
+    ShapedArray longitude = 2;
+
+    int64 time = 3;
+
+    ShapedArray variable_data = 4;
+
+    repeated MetaData meta_data = 5;
+
+    float depth = 6;
+
+}
+
 message SwathTile{
+
+    ShapedArray latitude = 1;
+    ShapedArray longitude = 2;
+    ShapedArray time = 3;
+
+    ShapedArray variable_data = 4;
+
+    repeated MetaData meta_data = 5;
+
+    float depth = 6;
+
+}
+
+message SwathMultiBandTile{
 
     ShapedArray latitude = 1;
     ShapedArray longitude = 2;
@@ -132,6 +161,7 @@ message TileSummary{
     }
     DataStats stats = 9;
     string standard_name = 10;
+    repeated string data_dim_names = 11;
 }
 
 message NexusTile{
@@ -147,5 +177,7 @@ message TileData{
         SwathTile swath_tile = 3;
         TimeSeriesTile time_series_tile = 4;
         EccoTile ecco_tile = 5;
+        GridMultiBandTile grid_multi_band_tile = 6;
+        SwathMultiBandTile swath_multi_band_tile = 7;
     }
 }

--- a/src/main/proto/DataTile.proto
+++ b/src/main/proto/DataTile.proto
@@ -51,7 +51,7 @@ message GridTile{
 
 }
 
-message GridMultiBandTile{
+message GridMultiVariableTile{
 
     ShapedArray latitude = 1;
     ShapedArray longitude = 2;
@@ -80,7 +80,7 @@ message SwathTile{
 
 }
 
-message SwathMultiBandTile{
+message SwathMultiVariableTile{
 
     ShapedArray latitude = 1;
     ShapedArray longitude = 2;
@@ -177,7 +177,7 @@ message TileData{
         SwathTile swath_tile = 3;
         TimeSeriesTile time_series_tile = 4;
         EccoTile ecco_tile = 5;
-        GridMultiBandTile grid_multi_band_tile = 6;
-        SwathMultiBandTile swath_multi_band_tile = 7;
+        GridMultiVariableTile grid_multi_variable_tile = 6;
+        SwathMultiVariableTile swath_multi_variable_tile = 7;
     }
 }

--- a/src/main/proto/DataTile.proto
+++ b/src/main/proto/DataTile.proto
@@ -102,7 +102,7 @@ message TileSummary{
     string dataset_name = 3;
     string granule = 4;
     string dataset_uuid = 5;
-    string data_var_name = 6;
+    repeated string data_var_name = 6;
     repeated Attribute global_attributes = 7;
 
     message BBox{

--- a/src/main/proto/DataTile.proto
+++ b/src/main/proto/DataTile.proto
@@ -131,7 +131,7 @@ message TileSummary{
     string dataset_name = 3;
     string granule = 4;
     string dataset_uuid = 5;
-    repeated string data_var_name = 6;
+    string data_var_name = 6;
     repeated Attribute global_attributes = 7;
 
     message BBox{


### PR DESCRIPTION
- add grid and swath multi band datatypes
- make data_var_name an array so that it can accept both single and multi band
- add data_dim_names which will store the names of each dimension (used in ForceAscendingLatitude Processor) 